### PR TITLE
28 Additional extensions methods for openapi 3.1.0 encoding / decoding

### DIFF
--- a/openapi-circe-yaml/src/main/scala/sttp/apispec/openapi/circe/yaml/SttpOpenAPICirceYaml.scala
+++ b/openapi-circe-yaml/src/main/scala/sttp/apispec/openapi/circe/yaml/SttpOpenAPICirceYaml.scala
@@ -8,18 +8,29 @@ import sttp.apispec.openapi.OpenAPI
 trait SttpOpenAPICirceYaml {
 
   implicit class RichOpenAPI(openAPI: OpenAPI) {
-    import sttp.apispec.openapi.circe._
 
-    def toYaml: String = Printer(dropNullKeys = true, preserveOrder = true).pretty(openAPI.asJson)
-    def toYaml(stringStyle: StringStyle): String =
+    /** Converts `OpenAPI` to Open Api 3.0.3 YAML string */
+    def toYaml: String = {
+      import sttp.apispec.openapi.circe._
+      Printer(dropNullKeys = true, preserveOrder = true).pretty(openAPI.asJson)
+    }
+
+    /** Converts `OpenAPI` to Open Api 3.0.3 YAML string */
+    def toYaml(stringStyle: StringStyle): String = {
+      import sttp.apispec.openapi.circe._
       Printer(dropNullKeys = true, preserveOrder = true, stringStyle = stringStyle).pretty(openAPI.asJson)
-  }
+    }
 
-  implicit class RichOpenAPI3_1(openAPI: OpenAPI) {
-    import sttp.apispec.openapi.circe_openapi_3_1._
+    /** Converts `OpenAPI` to Open Api 3.1.0 YAML string */
+    def toYaml3_1: String = {
+      import sttp.apispec.openapi.circe_openapi_3_1._
+      Printer(dropNullKeys = true, preserveOrder = true).pretty(openAPI.asJson)
+    }
 
-    def toYaml: String = Printer(dropNullKeys = true, preserveOrder = true).pretty(openAPI.asJson)
-    def toYaml(stringStyle: StringStyle): String =
+    /** Converts `OpenAPI` to Open Api 3.1.0 YAML string */
+    def toYaml3_1(stringStyle: StringStyle): String = {
+      import sttp.apispec.openapi.circe_openapi_3_1._
       Printer(dropNullKeys = true, preserveOrder = true, stringStyle = stringStyle).pretty(openAPI.asJson)
+    }
   }
 }

--- a/openapi-circe-yaml/src/main/scala/sttp/apispec/openapi/circe/yaml/SttpOpenAPICirceYaml.scala
+++ b/openapi-circe-yaml/src/main/scala/sttp/apispec/openapi/circe/yaml/SttpOpenAPICirceYaml.scala
@@ -4,10 +4,20 @@ import io.circe.syntax._
 import io.circe.yaml.Printer
 import io.circe.yaml.Printer.StringStyle
 import sttp.apispec.openapi.OpenAPI
-import sttp.apispec.openapi.circe._
 
 trait SttpOpenAPICirceYaml {
+
   implicit class RichOpenAPI(openAPI: OpenAPI) {
+    import sttp.apispec.openapi.circe._
+
+    def toYaml: String = Printer(dropNullKeys = true, preserveOrder = true).pretty(openAPI.asJson)
+    def toYaml(stringStyle: StringStyle): String =
+      Printer(dropNullKeys = true, preserveOrder = true, stringStyle = stringStyle).pretty(openAPI.asJson)
+  }
+
+  implicit class RichOpenAPI3_1(openAPI: OpenAPI) {
+    import sttp.apispec.openapi.circe_openapi_3_1._
+
     def toYaml: String = Printer(dropNullKeys = true, preserveOrder = true).pretty(openAPI.asJson)
     def toYaml(stringStyle: StringStyle): String =
       Printer(dropNullKeys = true, preserveOrder = true, stringStyle = stringStyle).pretty(openAPI.asJson)

--- a/openapi-circe/src/main/scala/sttp/apispec/openapi/circe/package.scala
+++ b/openapi-circe/src/main/scala/sttp/apispec/openapi/circe/package.scala
@@ -1,8 +1,13 @@
 package sttp.apispec.openapi
 
 import sttp.apispec.AnySchema
+import sttp.apispec.openapi.circe.{SttpOpenAPI3_1CirceEncoders, SttpOpenAPICirceDecoders}
 
 package object circe extends SttpOpenAPICirceEncoders with SttpOpenAPICirceDecoders {
+  override val anyObjectEncoding: AnySchema.Encoding = AnySchema.Encoding.Boolean
+}
+
+package object circe_openapi_3_1 extends SttpOpenAPI3_1CirceEncoders with SttpOpenAPICirceDecoders {
   override val anyObjectEncoding: AnySchema.Encoding = AnySchema.Encoding.Boolean
 }
 


### PR DESCRIPTION
* Next to the default `circe` package object extending OpenAPI 3.0.3 encoder/decoders added `circe_openapi_3_1` that is extedng OpenAPI 3.1.0 encoder/decoders.
* Introduced `toYaml3_1`  extension methods for generation OpenAPI 3.1.0 yaml string.