### PR TITLE
Added defaults to reduce boilerplate of creating asyncapi

### DIFF
--- a/asyncapi-model/src/main/scala/sttp/apispec/asyncapi/AsyncAPI.scala
+++ b/asyncapi-model/src/main/scala/sttp/apispec/asyncapi/AsyncAPI.scala
@@ -14,14 +14,14 @@ import sttp.apispec.{
 import scala.collection.immutable.ListMap
 
 case class AsyncAPI(
-    asyncapi: String = "2.0.0",
-    id: Option[String],
+    asyncapi: String = "2.6.0",
+    id: Option[String] = None,
     info: Info,
-    servers: ListMap[String, Server],
-    channels: ListMap[String, ReferenceOr[ChannelItem]],
-    components: Option[Components],
-    tags: List[Tag],
-    externalDocs: Option[ExternalDocumentation],
+    servers: ListMap[String, Server] = ListMap.empty,
+    channels: ListMap[String, ReferenceOr[ChannelItem]] = ListMap.empty,
+    components: Option[Components] = None,
+    tags: List[Tag] = Nil,
+    externalDocs: Option[ExternalDocumentation] = None,
     extensions: ListMap[String, ExtensionValue] = ListMap.empty
 ) {
   def id(id: String): AsyncAPI = copy(id = Some(id))
@@ -71,24 +71,42 @@ case class ServerVariable(
 )
 
 case class ChannelItem(
-    description: Option[String],
-    subscribe: Option[Operation],
-    publish: Option[Operation],
-    parameters: ListMap[String, ReferenceOr[Parameter]],
-    bindings: List[ChannelBinding],
+    description: Option[String] = None,
+    subscribe: Option[Operation] = None,
+    publish: Option[Operation] = None,
+    parameters: ListMap[String, ReferenceOr[Parameter]] = ListMap.empty,
+    bindings: List[ChannelBinding] = Nil,
     extensions: ListMap[String, ExtensionValue] = ListMap.empty
 )
+
+object ChannelItem {
+  def empty: ChannelItem =
+    ChannelItem()
+
+  def subscribe(op: Operation): ChannelItem = ChannelItem(subscribe = Some(op))
+
+  def publish(op: Operation): ChannelItem = ChannelItem(publish = Some(op))
+}
+
+
 case class Operation(
-    operationId: Option[String],
-    summary: Option[String],
-    description: Option[String],
-    tags: List[Tag],
-    externalDocs: Option[ExternalDocumentation],
-    bindings: List[OperationBinding],
-    traits: List[OperationTrait],
-    message: Option[ReferenceOr[Message]],
+    operationId: Option[String] = None,
+    summary: Option[String] = None,
+    description: Option[String] = None,
+    tags: List[Tag] = Nil,
+    externalDocs: Option[ExternalDocumentation] = None,
+    bindings: List[OperationBinding] = Nil,
+    traits: List[OperationTrait] = Nil,
+    message: Option[ReferenceOr[Message]] = None,
     extensions: ListMap[String, ExtensionValue] = ListMap.empty
 )
+
+object Operation {
+  def empty: Operation = Operation()
+
+  def inlineMessage(payload: Message): Operation =
+    Operation(message = Some(Right(payload)))
+}
 
 case class OperationTrait(
     operationId: Option[String],
@@ -139,6 +157,14 @@ case class WebSocketMessageBinding() extends MessageBinding
 case class KafkaMessageBinding(key: Option[Schema], bindingVersion: Option[String]) extends MessageBinding
 
 sealed trait Message
+
+object Message {
+  def singleInline(payload: String, schemaFormat: Option[String] = None): SingleMessage =
+    SingleMessage(
+      payload = Some(Left(AnyValue(payload))),
+      schemaFormat = schemaFormat
+    )
+}
 case class OneOfMessage(oneOf: List[SingleMessage]) extends Message
 case class SingleMessage(
     headers: Option[ReferenceOr[Schema]] = None,

--- a/build.sbt
+++ b/build.sbt
@@ -29,7 +29,7 @@ val scala3Settings = Seq(
 val commonSettings = commonSmlBuildSettings ++ ossPublishSettings ++ Seq(
   organization := "com.softwaremill.sttp.apispec",
   mimaPreviousArtifacts := Set.empty,
-  versionScheme := Some("semver-spec")
+  versionScheme := Some("early-semver")
 ) ++ scala3Settings
 
 val commonJvmSettings = commonSettings ++ Seq(
@@ -87,9 +87,9 @@ lazy val projectAggregates: Seq[ProjectReference] = if (sys.env.isDefinedAt("STT
 val compileAndTest = "compile->compile;test->test"
 
 lazy val rootProject = (project in file("."))
-  .settings(commonSettings: _*)
+  .settings(commonSettings*)
   .settings(publish / skip := true, name := "sttp-apispec", scalaVersion := scala2_13)
-  .aggregate(projectAggregates: _*)
+  .aggregate(projectAggregates*)
 
 lazy val circeTestUtils: ProjectMatrix = (projectMatrix in file("circe-testutils"))
   .settings(commonSettings)


### PR DESCRIPTION
Use case: I have a bunch of avro codecs, and I want to generate docs for Backstage

```scala

import org.apache.avro.Schema
import sttp.apispec.ReferenceOr
import sttp.apispec.asyncapi.*

import scala.collection.immutable.ListMap
import scala.jdk.CollectionConverters.*

case class EventDescription(schema: Schema, topic: String, pubSub: PubSub)

sealed trait PubSub

object PubSub {
  case object Subscribe extends PubSub

  case object Publish extends PubSub
}

def schemaToMessage(schema: Schema): Message =
  if (schema.isUnion)
    OneOfMessage(schema.getTypes.asScala.map(s => Message.singleInline(s.toString, Some("application/vnd.apache.avro+yaml;version=1.9.0"))).toList)
  else
    Message.singleInline(schema.toString, Some("application/vnd.apache.avro+yaml;version=1.9.0"))

def avroChannelMessage(schema: Schema, pubSub: PubSub): ChannelItem =
  pubSub match {
    case PubSub.Publish =>
      ChannelItem.publish(Operation.inlineMessage(schemaToMessage(schema)))
    case PubSub.Subscribe =>
      ChannelItem.subscribe(Operation.inlineMessage(schemaToMessage(schema)))
  }

def mkChannels(events: List[EventDescription]): ListMap[String, ReferenceOr[ChannelItem]] =
  ListMap.from(
    events.map(e => e.topic -> Right(avroChannelMessage(e.schema, e.pubSub)))
  )

def makeAsyncApi(title: String, version: String, events: List[EventDescription]): AsyncAPI = {

  AsyncAPI(
    info = Info(
      title = title,
      version = version
    ),
    channels = mkChannels(events)
  )
}
```