### PR TITLE
Allow doc extensions to override model's default attributes

### DIFF
--- a/asyncapi-model/src/main/scala/sttp/apispec/asyncapi/AsyncAPI.scala
+++ b/asyncapi-model/src/main/scala/sttp/apispec/asyncapi/AsyncAPI.scala
@@ -88,7 +88,6 @@ object ChannelItem {
   def publish(op: Operation): ChannelItem = ChannelItem(publish = Some(op))
 }
 
-
 case class Operation(
     operationId: Option[String] = None,
     summary: Option[String] = None,

--- a/jsonschema-circe/src/main/scala/sttp/apispec/internal/JsonSchemaCirceEncoders.scala
+++ b/jsonschema-circe/src/main/scala/sttp/apispec/internal/JsonSchemaCirceEncoders.scala
@@ -225,7 +225,7 @@ trait JsonSchemaCirceEncoders {
   private[apispec] def expandExtensions(jsonObject: JsonObject): JsonObject = {
     val extensions = jsonObject("extensions")
     val jsonWithoutExt = jsonObject.filterKeys(_ != "extensions")
-    extensions.flatMap(_.asObject).map(extObject => extObject.deepMerge(jsonWithoutExt)).getOrElse(jsonWithoutExt)
+    extensions.flatMap(_.asObject).map(extObject => jsonWithoutExt.deepMerge(extObject)).getOrElse(jsonWithoutExt)
   }
 
 }

--- a/openapi-circe/src/test/resources/petstore/basic-petstore.json
+++ b/openapi-circe/src/test/resources/petstore/basic-petstore.json
@@ -19,8 +19,18 @@
   "paths": {
     "/pets": {
       "get": {
-        "operationId": "getPets",
         "description": "Gets all pets",
+        "operationId": "getPets",
+        "parameters": [
+          {
+            "explode": true,
+            "name": "species",
+            "in": "query",
+            "schema": {
+              "type": "array"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "Success"

--- a/openapi-circe/src/test/scala/sttp/apispec/openapi/circe/DecoderTest.scala
+++ b/openapi-circe/src/test/scala/sttp/apispec/openapi/circe/DecoderTest.scala
@@ -2,8 +2,9 @@ package sttp.apispec
 package openapi
 package circe
 
-import sttp.apispec.test._
 import org.scalatest.funsuite.AnyFunSuite
+import sttp.apispec.test._
+
 import scala.collection.immutable.ListMap
 
 class DecoderTest extends AnyFunSuite with ResourcePlatform {

--- a/openapi-circe/src/test/scala/sttp/apispec/openapi/circe/EncoderTest.scala
+++ b/openapi-circe/src/test/scala/sttp/apispec/openapi/circe/EncoderTest.scala
@@ -46,6 +46,10 @@ class EncoderTest extends AnyFunSuite with ResourcePlatform with SttpOpenAPICirc
             operationId = Some("getPets"),
             description = Some("Gets all pets")
           ).addResponse(200, Response(description = "Success"))
+            .addParameter(
+              Parameter("species", ParameterIn.Query, schema = Some(refOr(Schema(SchemaType.Array))))
+                .addExtension("explode", ExtensionValue("true"))
+            )
         )
       )
     )


### PR DESCRIPTION
See https://softwaremill.community/t/explicit-explode-true-in-the-generated-openapi/280/3