### PR TITLE
Revert "Allow doc extensions to override model's default attributes"

### DIFF
--- a/asyncapi-model/src/main/scala/sttp/apispec/asyncapi/AsyncAPI.scala
+++ b/asyncapi-model/src/main/scala/sttp/apispec/asyncapi/AsyncAPI.scala
@@ -88,6 +88,7 @@ object ChannelItem {
   def publish(op: Operation): ChannelItem = ChannelItem(publish = Some(op))
 }
 
+
 case class Operation(
     operationId: Option[String] = None,
     summary: Option[String] = None,

--- a/jsonschema-circe/src/main/scala/sttp/apispec/internal/JsonSchemaCirceEncoders.scala
+++ b/jsonschema-circe/src/main/scala/sttp/apispec/internal/JsonSchemaCirceEncoders.scala
@@ -225,7 +225,7 @@ trait JsonSchemaCirceEncoders {
   private[apispec] def expandExtensions(jsonObject: JsonObject): JsonObject = {
     val extensions = jsonObject("extensions")
     val jsonWithoutExt = jsonObject.filterKeys(_ != "extensions")
-    extensions.flatMap(_.asObject).map(extObject => jsonWithoutExt.deepMerge(extObject)).getOrElse(jsonWithoutExt)
+    extensions.flatMap(_.asObject).map(extObject => extObject.deepMerge(jsonWithoutExt)).getOrElse(jsonWithoutExt)
   }
 
 }

--- a/openapi-circe/src/main/scala/sttp/apispec/openapi/internal/InternalSttpOpenAPICirceDecoders.scala
+++ b/openapi-circe/src/main/scala/sttp/apispec/openapi/internal/InternalSttpOpenAPICirceDecoders.scala
@@ -87,15 +87,7 @@ trait InternalSttpOpenAPICirceDecoders extends JsonSchemaCirceDecoders {
       extensions <- c.getOrElse[ListMap[String, ExtensionValue]]("extensions")(ListMap.empty)
     } yield Responses(responses, extensions)
   })
-  implicit val parameterDecoder: Decoder[Parameter] = {
-    implicit def listMapDecoder[A: Decoder]: Decoder[ListMap[String, ReferenceOr[A]]] =
-      Decoder.decodeOption(Decoder.decodeMapLike[String, ReferenceOr[A], ListMap]).map(_.getOrElse(ListMap.empty))
-
-    implicit def listMapMediaTypeDecoder: Decoder[ListMap[String, MediaType]] =
-      Decoder.decodeOption(Decoder.decodeMapLike[String, MediaType, ListMap]).map(_.getOrElse(ListMap.empty))
-
-    withExtensions(deriveDecoder[Parameter])
-  }
+  implicit val parameterDecoder: Decoder[Parameter] = withExtensions(deriveDecoder[Parameter])
   implicit val callbackDecoder: Decoder[Callback] = deriveDecoder[Callback]
   implicit val operationDecoder: Decoder[Operation] = {
     implicit def listMapDecoder[A: Decoder]: Decoder[ListMap[String, ReferenceOr[A]]] =

--- a/openapi-circe/src/test/resources/petstore/basic-petstore.json
+++ b/openapi-circe/src/test/resources/petstore/basic-petstore.json
@@ -19,18 +19,8 @@
   "paths": {
     "/pets": {
       "get": {
-        "description": "Gets all pets",
         "operationId": "getPets",
-        "parameters": [
-          {
-            "explode": true,
-            "name": "species",
-            "in": "query",
-            "schema": {
-              "type": "array"
-            }
-          }
-        ],
+        "description": "Gets all pets",
         "responses": {
           "200": {
             "description": "Success"

--- a/openapi-circe/src/test/scala/sttp/apispec/openapi/circe/DecoderTest.scala
+++ b/openapi-circe/src/test/scala/sttp/apispec/openapi/circe/DecoderTest.scala
@@ -2,9 +2,8 @@ package sttp.apispec
 package openapi
 package circe
 
-import org.scalatest.funsuite.AnyFunSuite
 import sttp.apispec.test._
-
+import org.scalatest.funsuite.AnyFunSuite
 import scala.collection.immutable.ListMap
 
 class DecoderTest extends AnyFunSuite with ResourcePlatform {

--- a/openapi-circe/src/test/scala/sttp/apispec/openapi/circe/EncoderTest.scala
+++ b/openapi-circe/src/test/scala/sttp/apispec/openapi/circe/EncoderTest.scala
@@ -46,10 +46,6 @@ class EncoderTest extends AnyFunSuite with ResourcePlatform with SttpOpenAPICirc
             operationId = Some("getPets"),
             description = Some("Gets all pets")
           ).addResponse(200, Response(description = "Success"))
-            .addParameter(
-              Parameter("species", ParameterIn.Query, schema = Some(refOr(Schema(SchemaType.Array))))
-                .addExtension("explode", ExtensionValue("true"))
-            )
         )
       )
     )


### PR DESCRIPTION
Reverts softwaremill/sttp-apispec#113

Unfortunately this change brakes tests in tapir: https://github.com/softwaremill/tapir/pull/3202
Until this is resolved, reverting the PR