### PR TITLE
Keep keys order when overriding model attributes with extensions

### DIFF
--- a/asyncapi-model/src/main/scala/sttp/apispec/asyncapi/AsyncAPI.scala
+++ b/asyncapi-model/src/main/scala/sttp/apispec/asyncapi/AsyncAPI.scala
@@ -88,7 +88,6 @@ object ChannelItem {
   def publish(op: Operation): ChannelItem = ChannelItem(publish = Some(op))
 }
 
-
 case class Operation(
     operationId: Option[String] = None,
     summary: Option[String] = None,


### PR DESCRIPTION
Hi again @adamw 

I believe this does what I want, without changing the order of keys: extensions can override attribute values, but they are added at the end. I ran relevant Tapir tests locally and they don't fail anymore.