### PR TITLE
Fixes async api encoding when using discriminator (#43).

### DIFF
--- a/asyncapi-circe/src/main/scala/sttp/apispec/asyncapi/circe/package.scala
+++ b/asyncapi-circe/src/main/scala/sttp/apispec/asyncapi/circe/package.scala
@@ -15,6 +15,11 @@ package circe {
   import sttp.apispec.internal.JsonSchemaCirceEncoders
 
   trait SttpAsyncAPICirceEncoders extends JsonSchemaCirceEncoders {
+    // note: avoids rendering of (unsupported) discriminator mapping
+    override implicit val encoderDiscriminator: Encoder[Discriminator] = {
+      case Discriminator(propertyName, _) => Json.obj("discriminator" := propertyName)
+    }
+
     // note: these are strict val-s, order matters!
     implicit val encoderReference: Encoder[Reference] = deriveEncoder[Reference]
     implicit def encoderReferenceOr[T: Encoder]: Encoder[ReferenceOr[T]] = {

--- a/asyncapi-circe/src/test/scala/sttp/apispec/asyncapi/circe/EncoderTest.scala
+++ b/asyncapi-circe/src/test/scala/sttp/apispec/asyncapi/circe/EncoderTest.scala
@@ -183,6 +183,33 @@ class EncoderTest extends AnyFunSuite {
     assert(expected === comp.asJson.deepDropNullValues)
   }
 
+  test("encode discriminator") {
+    val expected =
+      parse("""{
+              |  "payload" : {
+              |    "oneOf" : [
+              |      {
+              |        "$ref" : "Dog"
+              |      },
+              |      {
+              |        "$ref" : "Cat"
+              |      }
+              |    ],
+              |    "discriminator" : {
+              |      "discriminator" : "pet"
+              |    }
+              |  }
+              |}""".stripMargin)
+
+    val schema = Schema.oneOf(
+      List(Schema.referenceTo("", "Dog"), Schema.referenceTo("", "Cat")),
+      Some(Discriminator("pet", Some(ListMap("Dog" -> "Dog", "Cat" -> "Cat")))))
+    val message = SingleMessage(payload = Some(Right(schema)))
+
+    assert(expected === message.asJson.deepDropNullValues)
+  }
+
+
 
   def parse(s: String): Json = io.circe.parser.parse(s).fold(throw _, identity)
 }


### PR DESCRIPTION
Customizes json schema encoding for purpose of async-api rendering in order to remove unsupported discriminator mapping (leaving only discriminator field name). This behavior with proposed rendering of `const` constraint for coproducts (https://github.com/softwaremill/tapir/pull/3955) should allow correct rendering of async api spec for coproducts.