### PR TITLE
Support comparison of Schemas generated by `TapirSchemaToJsonSchema`

### DIFF
--- a/apispec-model/src/main/scala/sttp/apispec/validation/SchemaResolver.scala
+++ b/apispec-model/src/main/scala/sttp/apispec/validation/SchemaResolver.scala
@@ -1,0 +1,75 @@
+package sttp.apispec.validation
+
+import sttp.apispec.{AnySchema, Schema, SchemaLike}
+
+import scala.annotation.tailrec
+import scala.collection.immutable.ListMap
+
+class SchemaResolver(schemas: Map[String, Schema], referencePrefix: String) {
+
+  def discriminatorMapping(schema: Schema): ListMap[String, Schema] = {
+    // schema reference -> overridden discriminator value
+    val explicitDiscValueByRef = schema.discriminator.flatMap(_.mapping).getOrElse(ListMap.empty).map(_.swap)
+    // assuming that schema is valid and every reference in disc.mapping is also an element of oneOf/anyOf
+    ListMap.empty ++ (schema.oneOf ++ schema.anyOf).collect { case s @ ReferenceSchema(ref) =>
+      val discValue = explicitDiscValueByRef.getOrElse(
+        ref,
+        ref match {
+          case Reference(name) => name
+          case _ => throw new NoSuchElementException(s"no discriminator value specified for non-local reference $ref")
+        }
+      )
+      discValue -> s
+    }
+  }
+
+  @tailrec final def resolveAndNormalize(schema: SchemaLike): Schema = schema match {
+    case AnySchema.Anything => Schema.Empty
+    case AnySchema.Nothing  => Schema.Nothing
+    case s @ ReferenceSchema(Reference(name)) =>
+      resolveAndNormalize(
+        schemas.getOrElse(name, throw new NoSuchElementException(s"could not resolve schema reference ${s.$ref.get}"))
+      )
+    case s: Schema => normalize(s)
+  }
+
+  private object ReferenceSchema {
+    def unapply(schema: Schema): Option[String] =
+      schema.$ref.filter(ref => schema == Schema($ref = Some(ref)))
+  }
+
+  private object Reference {
+    def unapply(ref: String): Option[String] = Option(ref)
+      .filter(_.startsWith(referencePrefix))
+      .map(_.stripPrefix(referencePrefix))
+  }
+
+  private def normalize(schema: Schema): Schema =
+    schema.copy(
+      $comment = None,
+      $defs = None,
+      $schema = None,
+      title = None,
+      description = None,
+      default = None,
+      deprecated = None,
+      readOnly = None,
+      writeOnly = None,
+      examples = None,
+      externalDocs = None,
+      extensions = ListMap.empty
+    )
+}
+
+object SchemaResolver {
+  val ComponentsRefPrefix = "#/components/schemas/"
+
+  val DefsRefPrefix = "#/$defs/"
+
+  def components(schemas: Map[String, Schema]): SchemaResolver = new SchemaResolver(schemas, ComponentsRefPrefix)
+
+  def defsSchemas(schema: Schema): SchemaResolver = new SchemaResolver(
+    schema.$defs.getOrElse(Map.empty).collect { case (name, s: Schema) => name -> s },
+    DefsRefPrefix
+  )
+}

--- a/apispec-model/src/test/scala/sttp/apispec/validation/SchemaComparatorTest.scala
+++ b/apispec-model/src/test/scala/sttp/apispec/validation/SchemaComparatorTest.scala
@@ -2,7 +2,6 @@ package sttp.apispec.validation
 
 import org.scalatest.funsuite.AnyFunSuite
 import sttp.apispec._
-import sttp.apispec.validation.SchemaComparator.RefPrefix
 
 import scala.collection.immutable.ListMap
 
@@ -108,10 +107,11 @@ class SchemaComparatorTest extends AnyFunSuite {
   )
 
   private def ref(name: String): Schema =
-    Schema.referenceTo(SchemaComparator.RefPrefix, name)
+    Schema.referenceTo(SchemaResolver.ComponentsRefPrefix, name)
 
   private def compare(writerSchema: Schema, readerSchema: Schema): List[SchemaCompatibilityIssue] =
-    new SchemaComparator(writerSchemas, readerSchemas).compare(writerSchema, readerSchema)
+    new SchemaComparator(SchemaResolver.components(writerSchemas), SchemaResolver.components(readerSchemas))
+      .compare(writerSchema, readerSchema)
 
   test("ignoring annotations") {
     assert(compare(
@@ -481,11 +481,11 @@ class SchemaComparatorTest extends AnyFunSuite {
     assert(compare(
       Schema(
         oneOf = List(ref("Foo"), ref("Bar")),
-        discriminator = Some(Discriminator("type", Some(ListMap("WFoo" -> s"${RefPrefix}Foo"))))
+        discriminator = Some(Discriminator("type", Some(ListMap("WFoo" -> s"${SchemaResolver.ComponentsRefPrefix}Foo"))))
       ),
       Schema(
         oneOf = List(ref("Foo"), ref("Bar"), ref("Baz")),
-        discriminator = Some(Discriminator("type", Some(ListMap("RBar" -> s"${RefPrefix}Bar"))))
+        discriminator = Some(Discriminator("type", Some(ListMap("RBar" -> s"${SchemaResolver.ComponentsRefPrefix}Bar"))))
       ),
     ) == List(
       UnsupportedDiscriminatorValues(List("WFoo", "Bar"))
@@ -496,7 +496,7 @@ class SchemaComparatorTest extends AnyFunSuite {
     assert(compare(
       Schema(
         oneOf = List(ref("Foo"), ref("Bar")),
-        discriminator = Some(Discriminator("type", Some(ListMap("Baz" -> s"${RefPrefix}Bar"))))
+        discriminator = Some(Discriminator("type", Some(ListMap("Baz" -> s"${SchemaResolver.ComponentsRefPrefix}Bar"))))
       ),
       Schema(
         oneOf = List(ref("Foo"), ref("Baz")),


### PR DESCRIPTION
`TapirSchemaToJsonSchema` generates JsonSchema specification `http://json-schema.org/draft/2020-12/schema#` and uses `#/$defs/` prefixes to locate reference to schemas stored in `Schema.$defs` field.

This change adds support for both `#/$defs/` and `#/components/schemas/` and the choice is made by the user of `SchemaComparator` via the following helper methods

* `SchemaResolver.components`
* `SchemaResolver.defsSchemas`

Closes #172 and #170 

Test for `SchemaResolver.defsSchemas` relies on `TapirSchemaToJsonSchema` from tapir project and I will provide a PR with specification there