### PR TITLE
Drop nulls from header encoder

### DIFF
--- a/openapi-circe/src/main/scala/sttp/apispec/openapi/internal/InternalSttpOpenAPICirceEncoders.scala
+++ b/openapi-circe/src/main/scala/sttp/apispec/openapi/internal/InternalSttpOpenAPICirceEncoders.scala
@@ -33,7 +33,7 @@ trait InternalSttpOpenAPICirceEncoders extends JsonSchemaCirceEncoders {
   implicit val encoderSecurityScheme: Encoder[SecurityScheme] =
     deriveEncoder[SecurityScheme].dropNullsExpandExtensions
 
-  implicit val encoderHeader: Encoder[Header] = deriveEncoder[Header]
+  implicit val encoderHeader: Encoder[Header] = deriveEncoder[Header].dropNulls
   implicit val encoderExample: Encoder[Example] = deriveEncoder[Example].dropNullsExpandExtensions
   implicit val encoderResponse: Encoder[Response] = deriveEncoder[Response].dropNullsExpandExtensions
   implicit val encoderLink: Encoder[Link] = deriveEncoder[Link].dropNullsExpandExtensions

--- a/openapi-circe/src/test/resources/petstore/header-petstore.json
+++ b/openapi-circe/src/test/resources/petstore/header-petstore.json
@@ -1,0 +1,71 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Sample Pet Store App",
+    "summary": "A pet store manager.",
+    "description": "This is a sample server for a pet store.",
+    "termsOfService": "https://example.com/terms/",
+    "contact": {
+      "name": "API Support",
+      "url": "https://www.example.com/support",
+      "email": "support@example.com"
+    },
+    "license": {
+      "name": "Apache 2.0",
+      "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
+    },
+    "version": "1.0.1"
+  },
+  "servers": [
+    {
+      "url": "http://petstore.swagger.io/v1"
+    }
+  ],
+  "paths": {
+    "/pets": {
+      "get": {
+        "operationId": "getPets",
+        "description": "Gets all pets",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "headers": {
+              "Location": {
+                "required": true,
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Pet"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Pet": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
# About this PR
The [Header object](https://swagger.io/specification/#header-object) in the OpenAPI spec contains mutually exclusive fields and the changes in https://github.com/softwaremill/sttp-apispec/pull/207 caused the non-set field not to be dropped from the specification. This causes validation failures in openapi-generator. This PR updates the Encoder for Header to drop null fields.

Also fixes https://github.com/softwaremill/sttp-apispec/issues/128 (actually, it may have been working again before this change).