### PR TITLE
Fix const keyword being used in OpenAPI 3.0.3 (#241)

### DIFF
--- a/openapi-circe/src/test/resources/spec/3.0/const_and_enum.json
+++ b/openapi-circe/src/test/resources/spec/3.0/const_and_enum.json
@@ -1,0 +1,17 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "API",
+    "version": "1.0.0"
+  },
+  "components": {
+    "schemas": {
+      "const and enum" : {
+        "description" : "const and enum",
+        "enum" : [
+          "const1"
+        ]
+      }
+    }
+  }
+}

--- a/openapi-circe/src/test/resources/spec/3.0/schema.json
+++ b/openapi-circe/src/test/resources/spec/3.0/schema.json
@@ -58,6 +58,19 @@
         "maximum": 20,
         "description": "min/max"
       },
+      "const" : {
+        "description" : "const",
+        "enum" : [
+          "const1"
+        ]
+      },
+      "enum" : {
+        "description" : "enum",
+        "enum" : [
+          "enum1",
+          "enum2"
+        ]
+      },
       "exclusive min/max": {
         "minimum": 10,
         "exclusiveMinimum": true,

--- a/openapi-circe/src/test/resources/spec/3.1/schema.json
+++ b/openapi-circe/src/test/resources/spec/3.1/schema.json
@@ -68,6 +68,17 @@
         "maximum": 20,
         "description": "min/max"
       },
+      "const" : {
+        "const" : "const1",
+        "description" : "const"
+      },
+      "enum" : {
+        "description" : "enum",
+        "enum" : [
+          "enum1",
+          "enum2"
+        ]
+      },
       "exclusive min/max": {
         "exclusiveMinimum": 10,
         "exclusiveMaximum": 20,

--- a/openapi-circe/src/test/scala/sttp/apispec/openapi/circe/DecoderTest.scala
+++ b/openapi-circe/src/test/scala/sttp/apispec/openapi/circe/DecoderTest.scala
@@ -42,14 +42,14 @@ class DecoderTest extends AnyFunSuite with ResourcePlatform {
     val Right(openapi) = readJson("/spec/3.1/schema.json").flatMap(_.as[OpenAPI]): @unchecked
     assert(openapi.info.title === "API")
     val schemas = openapi.components.getOrElse(Components.Empty).schemas
-    assert(schemas.size === 13)
+    assert(schemas.size === 15)
   }
 
   test("all schemas types 3.0") {
     val Right(openapi) = readJson("/spec/3.0/schema.json").flatMap(_.as[OpenAPI]): @unchecked
     assert(openapi.info.title === "API")
     val schemas = openapi.components.getOrElse(Components.Empty).schemas
-    assert(schemas.size === 12)
+    assert(schemas.size === 14)
   }
 
   test("decode security scheme with not empty scopes") {

--- a/openapi-circe/src/test/scala/sttp/apispec/openapi/circe/threeone/EncoderTest.scala
+++ b/openapi-circe/src/test/scala/sttp/apispec/openapi/circe/threeone/EncoderTest.scala
@@ -121,7 +121,9 @@ class EncoderTest extends AnyFunSuite with ResourcePlatform {
         ),
         schemaComponent("exclusiveMinimum false")(Schema(minimum = Some(BigDecimal(10)))),
         schemaComponent("array")(Schema(SchemaType.Array).copy(items = Some(Schema(SchemaType.String)))),
-        schemaComponent("array with unique items")(Schema(SchemaType.Array).copy(uniqueItems = Some(true)))
+        schemaComponent("array with unique items")(Schema(SchemaType.Array).copy(uniqueItems = Some(true))),
+        schemaComponent("const")(Schema(const = Some("const1").map(ExampleSingleValue(_)))),
+        schemaComponent("enum")(Schema(`enum` = Some(List("enum1", "enum2").map(ExampleSingleValue(_)))))
       )
     )
 
@@ -156,6 +158,26 @@ class EncoderTest extends AnyFunSuite with ResourcePlatform {
 
     val openApiJson = fullSchemaOpenApi.copy(openapi = "3.0.1").asJson
     val Right(json) = readJson("/spec/3.0/schema.json"): @unchecked
+
+    assert(openApiJson.spaces2SortKeys == json.spaces2SortKeys)
+  }
+
+  test("replace const by single enum value in 3.0 schema") {
+    import sttp.apispec.openapi.circe_openapi_3_0_3._
+
+    val components = Components(
+      schemas = ListMap(
+        schemaComponent("const and enum")(Schema(
+          const = Some("const1").map(ExampleSingleValue(_)),
+          `enum` = Some(List("enum1", "enum2").map(ExampleSingleValue(_)))))
+      )
+    )
+
+    val openApiJson = fullSchemaOpenApi.copy(
+      openapi = "3.0.1",
+      components = Some(components)
+    ).asJson
+    val Right(json) = readJson("/spec/3.0/const_and_enum.json"): @unchecked
 
     assert(openApiJson.spaces2SortKeys == json.spaces2SortKeys)
   }


### PR DESCRIPTION
Fixes issue #241 so that for OpenAPI 3.0.3 the `const` keyword gets replaced be a single valued `enum`.